### PR TITLE
Determine Git directory correctly

### DIFF
--- a/src/geocommit/__init__.py
+++ b/src/geocommit/__init__.py
@@ -56,8 +56,10 @@ class GeoGit(object):
         forward_system(["git", name] + argv, read_stdin)
 
     def install_hooks(self, directory):
-        git_dir = system("git rev-parse --show-toplevel", directory).strip('\n\r ') + "/"
-        git_dir += system("git rev-parse --git-dir", directory).strip('\n\r ')
+        git_dir = os.path.join(
+                system("git rev-parse --show-toplevel", directory).strip('\n\r '),
+                system("git rev-parse --git-dir", directory).strip('\n\r ')
+        )
 
         hooks = {
             "post-commit": ["#!/bin/sh\n", "git geo note\n"],


### PR DESCRIPTION
`git rev-parse --git-dir` returns the _absolute_ path (unless `$GIT_DIR`
was set to something like `.` ).

```
Installing geocommit hook in
/home/grawity/src/geocommit//home/grawity/src/geocommit/.git/hooks/post-rewrite
Traceback (most recent call last):
  File "/home/grawity/.local/bin/git-geo", line 9, in <module>
    load_entry_point('geocommit==0.9.3beta1', 'console_scripts', 'git-geo')()
  File "/home/grawity/.local/lib/python2.7/site-packages/geocommit/__init__.py", line 300, in git_geo
    f(sys.argv[2:])
  File "/home/grawity/.local/lib/python2.7/site-packages/geocommit/__init__.py", line 165, in cmd_setup
    self.install_hooks(".")
  File "/home/grawity/.local/lib/python2.7/site-packages/geocommit/__init__.py", line 69, in install_hooks
    self.install_hook(git_dir, hook, code)
  File "/home/grawity/.local/lib/python2.7/site-packages/geocommit/__init__.py", line 90, in install_hook
    f = open(hook, "w")
IOError: [Errno 2] No such file or directory: '/home/grawity/src/geocommit//home/grawity/src/geocommit/.git/hooks/post-rewrite'
```
